### PR TITLE
Add deployment.yaml for bot to kubernetes repo

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,16 @@
+## Bot
+
+Deployment file for @Python, our valiant community bot and workhorse.
+
+## Secrets
+This deployment expects a number of secrets and environment variables to exist in a secret called `bot-env`.
+
+
+| Environment           | Description                               |
+|-----------------------|-------------------------------------------|
+| BOT_API_TOKEN         | The token to access our API.              |
+| BOT_TOKEN             | The bot token to run the bot on.          |
+| REDDIT_CLIENT_ID      | The client ID to access the reddit API    |
+| REDDIT_SECRET         | The client secret for the Reddit API      |
+| REDIS_PASSWORD        | The password to access Redis              |
+| SITE_URL              | The base URL for our website.             |

--- a/bot/deployment.yaml
+++ b/bot/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bot
+  template:
+    metadata:
+      labels:
+        app: bot
+    spec:
+      containers:
+      - name: bot
+        image: ghcr.io/python-discord/bot:latest
+        imagePullPolicy: Always
+        envFrom:
+        - secretRef:
+            name: bot-env


### PR DESCRIPTION
I've added the bot's `deployment.yaml` file to this repository. That way, I can modify the bot's workflow to use the file located in this repository instead of a file located in its own repository.