### PR TITLE
Add deployment.yaml for site to kubernetes repo

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -1,4 +1,13 @@
 # Python Discord Site
-This folder contains some non-public manifests for Python Discord site.
+This folder contains the manifests for Python Discord site.
 
-The actual site deployment manifest can be found inside the site repository at [python-discord/site](https://github.com/python-discord/site).
+## Secrets
+
+The deployment expects the following secrets to be available in `site-env`:
+
+| Environment           | Description                               |
+|-----------------------|-------------------------------------------|
+| DATABASE_URL          | The URL for the Postgresql database.      |
+| METRICITY_DB_URL      | The URL for the Metricity database.       |
+| SECRET_KEY            | Secret key for Django.                    |
+| SENTRY_DSN            | The Sentry Data Source Name.              |

--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: site
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: site
+  template:
+    metadata:
+      labels:
+        app: site
+    spec:
+      containers:
+        - name: site
+          image: ghcr.io/python-discord/site:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - secretRef:
+                name: site-env


### PR DESCRIPTION
Same deal as with `bot`: I'm adding the `deployment.yaml` file to the kubernetes repo so we can remove it from the `site` repo.