### PR TITLE
Add PostgreSQL exporter

### DIFF
--- a/exporters/README.md
+++ b/exporters/README.md
@@ -1,0 +1,8 @@
+# Exporters
+This directory contains prometheus exporters for various services running on our cluster.
+
+If any secrets are required for each exporter they will be documented **in a comment at the top of the YAML file**.
+
+Below is a list of the exporters:
+- [postgres_exporter](https://github.com/wrouesnel/postgres_exporter)
+

--- a/exporters/postgres_exporter.yaml
+++ b/exporters/postgres_exporter.yaml
@@ -1,0 +1,43 @@
+# Exporter for taking statistics on our PostgreSQL instance
+#
+# Required secrets:
+#   - postgres-exporter-env
+#
+#       Should contain environment variables listed at https://github.com/wrouesnel/postgres_exporter but most
+#       notably should contain DATA_SOURCE_NAME containing a postgresql connection URI.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres-exporter
+  template:
+    metadata:
+      labels:
+        app: postgres-exporter
+    spec:
+      containers:
+        - name: postgres-exporter
+          image: wrouesnel/postgres_exporter:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9187
+          envFrom:
+            - secretRef:
+                name: postgres-exporter-env
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-exporter
+spec:
+  selector:
+    app: postgres-exporter
+  ports:
+    - protocol: TCP
+      port: 9187
+      targetPort: 9187


### PR DESCRIPTION
Adds the PostgreSQL exporter and the relevant documentation for it.

This exposes the exporter as a service which Prometheus can then pull from.

The service is live and can be reached on port `9187` of the `postgres-exporter` service.
