### PR TITLE
Migrate backup config to blackbox v2.

### DIFF
--- a/blackbox/blackbox-configmap.yaml
+++ b/blackbox/blackbox-configmap.yaml
@@ -22,9 +22,14 @@ data:
 
     storage:
       s3:
-        main_s3:
+        frankfurt_s3:
           bucket: blackbox
           endpoint: eu-central-1.linodeobjects.com
+          aws_access_key_id: {{ AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: {{ AWS_SECRET_ACCESS_KEY }}
+        newark_s3:
+          bucket: blackbox
+          endpoint: us-east-1.linodeobjects.com
           aws_access_key_id: {{ AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: {{ AWS_SECRET_ACCESS_KEY }}
 


### PR DESCRIPTION
**This should be merged after we update [blackbox](https://github.com/lemonsaurus/blackbox) to v2.** (which isn't out yet 😎)

This blackbox update also allows us to specify multiple storage handlers/notifiers, as well as specify which storage/notifier to use for each database backed up.

Good time to back up to different regions in case of a fire :fire:, also perfect for testing blackbox v2 in production :crab: