### PR TITLE
Bumps Grafana From 7.5.0 To 7.5.4

### DIFF
--- a/grafana/deployment-grafana.yaml
+++ b/grafana/deployment-grafana.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: grafana
-          image: grafana/grafana:7.5.0
+          image: grafana/grafana:7.5.4
           imagePullPolicy: Always
           ports:
             - containerPort: 3000


### PR DESCRIPTION
Just a routine version bump.

[Release notes](https://grafana.com/docs/grafana/latest/release-notes/) are available here.

Nothing noteworthy, just minor bug fixes and features.