### PR TITLE
Bitwarden: migrate to vaultwarden/server

### DIFF
--- a/bitwarden/deployment.yaml
+++ b/bitwarden/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: bitwarden
-          image: bitwardenrs/server-postgresql:latest
+          image: vaultwarden/server:latest
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
The `bitwarden/server-*` have been deprecated in favor of `vaultwarden/server`. It should be a drop-in replacement.

They claim that no data loss will occur, although we should trigger a black-box backup before merging, to be safe.