### PR TITLE
Add Thread Bot

### DIFF
--- a/thread-bot/README.md
+++ b/thread-bot/README.md
@@ -1,0 +1,12 @@
+## Thread Bot
+A bot purely to be our thread testing ground until Discord.py 2.0 is released fully.
+
+## Secrets
+This deployment expects a few secrets and environment variables to exist in a secret called `thread-bot-env`.
+
+
+| Environment           | Description                                             |
+|-----------------------|---------------------------------------------------------|
+| BOT_TOKEN             | The bot token to run the bot on.                        |
+| DEBUG                 | Should the bot start in DEBUG mode? Defaults to false.  |
+

--- a/thread-bot/deployment.yaml
+++ b/thread-bot/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thread-bot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: thread-bot
+  template:
+    metadata:
+      labels:
+        app: thread-bot
+    spec:
+      containers:
+      - name: thread-bot
+        image: ghcr.io/python-discord/thread-bot:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 400m
+            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 200Mi
+        envFrom:
+        - secretRef:
+            name: thread-bot-env


### PR DESCRIPTION
Adds our thread testing bot, source found here:
https://github.com/python-discord/thread-bot

Currently does nothing, but should be deployable.