### PR TITLE
Alter alertmanager thresholds

### DIFF
--- a/monitoring/alerts/alerts.d/coredns.yaml
+++ b/monitoring/alerts/alerts.d/coredns.yaml
@@ -12,7 +12,7 @@ groups:
       description: "Number of CoreDNS panics encountered: {{ $value }}"
 
   - alert: CoreDNSCacheMisses
-    expr: rate(coredns_cache_misses_total{}[10m]) / rate(coredns_cache_misses_total{}[10m] offset 10m) > 1.2
+    expr: rate(coredns_cache_misses_total{}[10m]) / rate(coredns_cache_misses_total{}[10m] offset 10m) > 1.5
     labels:
       severity: page
     annotations:

--- a/monitoring/alerts/alerts.d/nginx.yaml
+++ b/monitoring/alerts/alerts.d/nginx.yaml
@@ -22,7 +22,7 @@ groups:
       description: 'Rate of 5XX errors is {{ $value | humanizePercentage }}'
 
   - alert: NGINXP99Timing
-    expr: histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket[2m])) by (host, service, le)) > 3
+    expr: histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{service!~"(pydis-api|grafana)"}[2m])) by (host, service, le)) > 3
     for: 1m
     labels:
       severity: page


### PR DESCRIPTION
This PR:
- bumps the CoreDNSCacheMisses threshold to 150% 
- Ignores pydis-api and grafana for the NGINXP99Timing alert