### PR TITLE
Use the correct service name for the pydis-api

### DIFF
--- a/monitoring/alerts/alerts.d/nginx.yaml
+++ b/monitoring/alerts/alerts.d/nginx.yaml
@@ -22,7 +22,7 @@ groups:
       description: 'Rate of 5XX errors is {{ $value | humanizePercentage }}'
 
   - alert: NGINXP99Timing
-    expr: histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{service!~"(pydis-api|grafana)"}[2m])) by (host, service, le)) > 3
+    expr: histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{service!~"(site|grafana)"}[2m])) by (host, service, le)) > 3
     for: 1m
     labels:
       severity: page


### PR DESCRIPTION
pydis-api is the subdomain, the actual service name is site