### PR TITLE
Alerts: ignore prestashop

### DIFF
--- a/monitoring/alerts/alerts.d/nginx.yaml
+++ b/monitoring/alerts/alerts.d/nginx.yaml
@@ -21,7 +21,7 @@ groups:
       description: "Rate of 5XX errors is {{ $value | humanizePercentage }} on service `{{ $labels.service }}`"
 
   - alert: NGINXP99Timing
-    expr: histogram_quantile(0.99, sum by(host, service, le) (rate(nginx_ingress_controller_request_duration_seconds_bucket{service!~"(grafana|metabase)", host!="pydis-api.default.svc.cluster.local"}[5m]))) > 3
+    expr: histogram_quantile(0.99, sum by(host, service, le) (rate(nginx_ingress_controller_request_duration_seconds_bucket{service!~"(grafana|metabase|prestashop-svc)", host!="pydis-api.default.svc.cluster.local"}[5m]))) > 3
     for: 5m
     labels:
       severity: page


### PR DESCRIPTION
Turns out PHP apps are so bad that they trigger an alert every time they are used. Let's ignore them.