### PR TITLE
AlertManager High Availability

### DIFF
--- a/monitoring/alerts/alertmanager/daemonset.yaml
+++ b/monitoring/alerts/alertmanager/daemonset.yaml
@@ -8,7 +8,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: "100%"
-      maxSurge: "50%"
+      maxSurge: "100%"
   selector:
     matchLabels:
       app: alertmanager

--- a/monitoring/alerts/alertmanager/daemonset.yaml
+++ b/monitoring/alerts/alertmanager/daemonset.yaml
@@ -1,9 +1,14 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: alertmanager
   namespace: monitoring
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "100%"
+      maxSurge: "50%"
   selector:
     matchLabels:
       app: alertmanager
@@ -16,14 +21,20 @@ spec:
       - image: prom/alertmanager:latest
         imagePullPolicy: Always
         name: alertmanager
-        args: [
-          "--config.file=/opt/pydis/alertmanager/config.d/alertmanager.yaml",
-          "--web.external-url=https://alertmanager.pythondiscord.com",
-          "--storage.path=/data/alertmanager"
-        ]
+        command:
+          - /bin/sh
+          - -c
+          - |
+            exec /bin/alertmanager \
+              --config.file=/opt/pydis/alertmanager/config.d/alertmanager.yaml \
+              --web.external-url=https://alertmanager.pythondiscord.com \
+              --storage.path=/data/alertmanager \
+              $(nslookup -type=A alertmanager-sd.monitoring.svc.cluster.local | grep -E "Address: " | awk '{ print "--cluster.peer="$2":9094"; }')
         ports:
-        - name: alertmanager
+        - name: am
           containerPort: 9093
+        - name: am-peering
+          containerPort: 9094
         volumeMounts:
         - name: alertmanager-config
           mountPath: /opt/pydis/alertmanager/config.d

--- a/monitoring/alerts/alertmanager/sd-service.yaml
+++ b/monitoring/alerts/alertmanager/sd-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-sd
+  namespace: monitoring
+spec:
+  selector:
+    app: alertmanager
+  clusterIP: None
+  ports:
+  - port: 9093
+    targetPort: 9093
+    name: am
+  - port: 9094
+    targetPort: 9094
+    name: am-peering

--- a/monitoring/alerts/alertmanager/service.yaml
+++ b/monitoring/alerts/alertmanager/service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: alertmanager
   namespace: monitoring
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9093"
 spec:
   selector:
     app: alertmanager

--- a/monitoring/alerts/alerts.d/alertmanager.yaml
+++ b/monitoring/alerts/alerts.d/alertmanager.yaml
@@ -1,0 +1,21 @@
+groups:
+- name: alertmanager
+  rules:
+
+  - alert: AlertManagerClusterFailedPeers
+    expr: alertmanager_cluster_failed_peers > 0
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "An Alertmanager node is reporting failed peers"
+      description: "AM {{ $labels.instance }} is reporting that {{ $value }} of it's peers is invalid."
+
+  - alert: AlertManagerHealthScore
+    expr: alertmanager_cluster_health_score > 0
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "An AlertManagerNode is reporting an unhealthy cluster"
+      description: "AM {{ $labels.instance }} is reporting that the cluster has a health score of {{ $value }} (where 0 is healthy.)"

--- a/monitoring/prometheus/prometheus-config.yaml
+++ b/monitoring/prometheus/prometheus-config.yaml
@@ -15,9 +15,11 @@ data:
     alerting:
       alertmanagers:
         - scheme: http
-          static_configs:
-          - targets:
-            - alertmanager.monitoring.svc.cluster.local:9093
+          dns_sd_configs:
+          - names:
+            - alertmanager-sd.monitoring.svc.cluster.local
+            type: A
+            port: 9093
 
     # Scrape configs for running Prometheus on a Kubernetes cluster.
     # This uses separate scrape configs for cluster components (i.e. API server, node)


### PR DESCRIPTION
This PR changes our single-node AlertManager to a multi-node clustered HA deployment of AlertManager, with one AM instance running on every node of our cluster.

It adjusts Prometheus to fetch all AM instances from DNS.

Closes #83.