### PR TITLE
Add `PROMETHEUS_MULTIPROC_DIR` environment variable.

### DIFF
--- a/site/deployment.yaml
+++ b/site/deployment.yaml
@@ -47,12 +47,17 @@ spec:
             requests:
               cpu: 250m
               memory: 400Mi
+          env:
+            - name: PROMETHEUS_MULTIPROC_DIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: site-env
             - secretRef:
                 name: sentry-env
           volumeMounts:
+            # Used for `gunicorn` worker heartbeats as well as the Prometheus
+            # client library's multiprocessing mode.
             - name: django-tmp
               mountPath: /tmp
           securityContext:


### PR DESCRIPTION
See https://github.com/python-discord/site/pull/575

I already `kubectl apply`d this. I don't know why, I just did. It said configured, and nothing happened. I think it will be there on the next restart. I am not sure.

Actually, site has just restarted. So this is already live. I have made my first Kubernetes production deployment. For you it's daily business, for me it's beauty.