### PR TITLE
Deploy PyDis's ModMail fork

### DIFF
--- a/namespaces/default/modmail/bot/deployment.yaml
+++ b/namespaces/default/modmail/bot/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: modmail-bot
-          image: kyb3rr/modmail:latest
+          image: ghcr.io/python-discord/modmail:2c738ed
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
The original maintainers rarely push to docker hub now, so we have forked the repo and started pushing to GHCR instead.

Pinned to a specific commit as I'm not sure how much we should trust commit-commit deployments.