### PR TITLE
Correct capitalization of environment variable name.

### DIFF
--- a/namespaces/default/site/deployment.yaml
+++ b/namespaces/default/site/deployment.yaml
@@ -48,7 +48,9 @@ spec:
               cpu: 250m
               memory: 400Mi
           env:
-            - name: PROMETHEUS_MULTIPROC_DIR
+            # Needs to match with the variable name being read in django-prometheus
+            # https://github.com/korfuri/django-prometheus/blob/434a3ba36bdada45c9633451f5f6cfd145814ccf/django_prometheus/exports.py#L119
+            - name: prometheus_multiproc_dir
               value: /tmp
           envFrom:
             - secretRef:


### PR DESCRIPTION
When I initially deployed this, I used an uppercase variable name as
later versions of the Prometheus client library (all of which I am using
in various of my projects) switched to uppercase and deprecated the old
way of specifying this variable. Unfortunately the `django-prometheus`
library uses a lowercase variable to check whether the multiprocess mode
is in use, so we were collecting per-worker metrics the entire time,
which completely messed up our time series.


> wathat the fuck
> that is not the bug
> no shot is that the bug
> no FUCKING SHOT IS THAT THE BUG
> i'm going to go to war
> 
> - Joe