### PR TITLE
Bump modmail version

### DIFF
--- a/namespaces/default/modmail/bot/deployment.yaml
+++ b/namespaces/default/modmail/bot/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: modmail-bot
-          image: ghcr.io/python-discord/modmail:3ea840f
+          image: ghcr.io/python-discord/modmail:be55a29
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
Updated the monkey patch to use .utcnow() to avoid issues with dayliught savings, and dropped the logging level as it is quite spammy.