### PR TITLE
Update modmail pinned version

### DIFF
--- a/namespaces/default/modmail/bot/deployment.yaml
+++ b/namespaces/default/modmail/bot/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: modmail-bot
-          image: ghcr.io/python-discord/modmail:574eb60
+          image: ghcr.io/python-discord/modmail:1d241a1
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
This has already been applied to the cluster to confirm it works.

I reverted our dev -> master merge and cherry picked some commits that fix a bug that caused un-cached users to not be able to open threads.