### PR TITLE
Ability to use pg_cron in metricity

### DIFF
--- a/namespaces/default/postgresql/configmap.yaml
+++ b/namespaces/default/postgresql/configmap.yaml
@@ -756,4 +756,5 @@ data:
     #------------------------------------------------------------------------------
 
     # Add settings for extensions here
-
+    shared_preload_libraries = 'pg_cron'
+    cron.database_name = 'metricity'

--- a/namespaces/default/postgresql/deployment.yaml
+++ b/namespaces/default/postgresql/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:14
+          image: ghcr.io/chrislovering/psql_pg_cron:14
           imagePullPolicy: "Always"
           ports:
             - name: postgres


### PR DESCRIPTION
This updates the image we use for postgres to https://github.com/ChrisLovering/psql_pg_cron as it has pg_cron pre-installed.

This also adds the required config to postgresql.conf to allow the lib to be used.