### PR TITLE
Bump memory available to postgres

### DIFF
--- a/namespaces/default/postgresql/configmap.yaml
+++ b/namespaces/default/postgresql/configmap.yaml
@@ -133,7 +133,8 @@ data:
               # (change requires restart)
     # Caution: it is not advisable to set max_prepared_transactions nonzero unless
     # you actively intend to use prepared transactions.
-    #work_mem = 4MB				# min 64kB
+    work_mem = 32MB				# min 64kB
+    hash_mem_multiplier = 1.5
     #maintenance_work_mem = 64MB		# min 1MB
     #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
     #max_stack_depth = 2MB			# min 100kB


### PR DESCRIPTION
A lot of larger queries are having to use disk for intermediate storage, due to being memory starved. By increasing the memory available to psql, we should see improved performance.

hash_mem_multiplier is a multiplier on work_mem specifically for hash operations, this allows hash operations to complete quickly without other operations using up too much memory.