### PR TITLE
Move the latex cache to another dir

### DIFF
--- a/namespaces/default/sir-lancebot/deployment.yaml
+++ b/namespaces/default/sir-lancebot/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           readOnlyRootFilesystem: true
         volumeMounts:
             - name: lancebot-data-vol
-              mountPath: /bot/_latex_cache
+              mountPath: /bot/exts/fun/_latex_cache
             - name: lancebot-logs-vol
               mountPath: /bot/bot/log
             - name: lancebot-tmp-vol


### PR DESCRIPTION
This lance PR https://github.com/python-discord/sir-lancebot/pull/1010 moves the latex cache to be closer to the cog, this change reflects that, to allow for writing to that path.