### PR TITLE
Remove file extensions from locked URLs for hastebin

### DIFF
--- a/namespaces/default/hastebin/init-configmap.yaml
+++ b/namespaces/default/hastebin/init-configmap.yaml
@@ -25,6 +25,7 @@ data:
     # JS code changes significantly. It makes the URL display as "file" 
     # instead of "file.py" when you save a file, which makes it possible
     # to share the URL without triggering Discord's suspicious URL filter.
+    mv /init/monkeypatch_extensions.sh ./monkeypatch_extensions.sh
     chmod +x monkeypatch_extensions.sh
     ./monkeypatch_extensions.sh 
     

--- a/namespaces/default/hastebin/init-configmap.yaml
+++ b/namespaces/default/hastebin/init-configmap.yaml
@@ -3,12 +3,38 @@ kind: ConfigMap
 metadata:
   name: hastebin-init
 data:
+  monkeypatch_extensions.sh: |
+    #!/bin/bash
+
+    ORIGINAL="file += '\.' + _this.lookupExtensionByType(ret\.language);"
+    PATCHED="\/\/file += '\.' + _this.lookupExtensionByType(ret\.language);"
+    FILENAME="static/application.js"
+    
+    touch changed
+    sed -i "s/$ORIGINAL/$PATCHED/w changed" "$FILENAME"
   init.sh: |
     #!/bin/bash
 
     # Clone the repo
     git clone https://github.com/seejohnrun/haste-server.git
     cd haste-server
+    
+    # Monkey patch - don't add extensions to the URLs.
+    # 
+    # This is a pretty messy monkey patch, and it may break if the hastebin
+    # JS code changes significantly. It makes the URL display as "file" 
+    # instead of "file.py" when you save a file, which makes it possible
+    # to share the URL without triggering Discord's suspicious URL filter.
+    chmod +x monkeypatch_extensions.sh
+    ./monkeypatch_extensions.sh 
+    
+    # Check if monkeypatch succeeded. Otherwise, fail hard.
+    if [ -s changed ]; then
+      echo "Monkey patch executed: Hastebin will no longer add extensions to URLs."
+    else
+      echo "Monkey patch for not adding extension could not be performed. Maybe the hastebin code has changed?"
+      exit 69
+    fi
 
     # Install and start
     npm install

--- a/namespaces/default/hastebin/init-configmap.yaml
+++ b/namespaces/default/hastebin/init-configmap.yaml
@@ -16,7 +16,7 @@ data:
     #!/bin/bash
 
     # Clone the repo
-    git clone https://github.com/seejohnrun/haste-server.git
+    git clone https://github.com/toptal/haste-server.git
     cd haste-server
     
     # Monkey patch - don't add extensions to the URLs.

--- a/namespaces/default/hastebin/init-configmap.yaml
+++ b/namespaces/default/hastebin/init-configmap.yaml
@@ -25,7 +25,7 @@ data:
     # JS code changes significantly. It makes the URL display as "file" 
     # instead of "file.py" when you save a file, which makes it possible
     # to share the URL without triggering Discord's suspicious URL filter.
-    mv /init/monkeypatch_extensions.sh ./monkeypatch_extensions.sh
+    cp /init/monkeypatch_extensions.sh ./monkeypatch_extensions.sh
     chmod +x monkeypatch_extensions.sh
     ./monkeypatch_extensions.sh 
     


### PR DESCRIPTION
Recently, Discord has implemented a suspicious file scanning feature which marks any URL with a `.py` in it as a suspicious URL. 

This means, users who use our paste.pythondiscord.com service will be met with this lovely screen:

![image](https://user-images.githubusercontent.com/2098517/154565870-5a21c812-8707-4136-ae98-21ef9e3775e6.png)

This hideous monster of a monkey patch will comment out the line of code that adds the file extension to the URL, thereby ensuring that you will just get a flat URL when you save. E.g., instead of `paste.pythondiscord.com/omaimadnaoida.py`, you'll just get `paste.pythondiscord.com/omaimadnaoida` when you hit save.

I've made this monkeypatch fail hard if it fails, so if the code changes and this approach is no longer viable, it should break the entire build, thereby alerting us that we need to change (or remove) the monkey patch to build this service. That seems better than silently failing to remove the .py and reintroducing the bug.

## How does this work?
It just comments out a single line in haste-server, which is responsible for adding this extension to the URL before it gets pushed to your history. The specific line and the context can be found here:
https://github.com/toptal/haste-server/blob/master/static/application.js#L249

## Why a monkey patch?
Because forking haste-server means maintaining the fork. This will theoretically keep working until this particular line is changed, and honestly it would be weird if that _ever_ happened, this line is very simple and I can't imagine why they would change it at all.

It's likely that this will work for the foreseeable future, and without forcing us to maintain a fork, and without missing out on future updates. We can keep using the latest version of this tool, and if it breaks, we'll just adjust the monkeypatch or get rid of it. It's not a big deal, it'll just fail to deploy. Users won't even notice.