### PR TITLE
Add basic deployment for sir-robin bot

### DIFF
--- a/namespaces/default/sir-robin/README.md
+++ b/namespaces/default/sir-robin/README.md
@@ -1,0 +1,19 @@
+## Sir-Robin
+Deployment file for @Sir-Robin, the not-quite-so-bot as Sir Lancebot, is our humble events bot.
+He is tasked with dealing with all the things that the event team can throw at it!
+
+## Secrets
+This deployment expects a number of secrets/environment variables to exist in a secret called `sir-robin-env`.
+
+The secrets are:
+```
+BOT_TOKEN - The Discord bot token for Sir Robin to connect to Discord with
+SITE_URL - The base URL for our website.
+SITE_API_TOKEN - The token to access the site API.
+BOT_DEBUG - Whether debug is enabled (true/false).
+```
+
+Sir Robin also requires the below secret to redis, which is pulled from the `redis-credentials` secret.
+```
+REDIS_PASSWORD - The password to redis
+```

--- a/namespaces/default/sir-robin/deployment.yaml
+++ b/namespaces/default/sir-robin/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sir-robin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sir-robin
+  template:
+    metadata:
+      labels:
+        app: sir-robin
+    spec:
+      securityContext:
+        fsGroup: 2000
+        runAsUser: 1000
+        runAsNonRoot: true
+      containers:
+      - name: sir-robin
+        image: ghcr.io/python-discord/sir-robin:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 500m
+            memory: 300Mi
+          limits:
+            cpu: 750m
+            memory: 500Mi
+        envFrom:
+        - secretRef:
+            name: sir-robin-env
+        - secretRef:
+            name: redis-credentials
+        securityContext:
+          readOnlyRootFilesystem: true


### PR DESCRIPTION
https://github.com/python-discord/sir-robin/pull/12 adds a deployment workflow to Sir-Robin, once that is merged merged I will setup the secrets and use this manifest to test the deployment. If all goes well I will then add the auto-deploy job to the build flow in sir-robin.