### PR TITLE
Update path to docs theme due to rename

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,7 +7,7 @@ url: "https://python-discord.github.io"
 twitter_username: PythonDiscord
 github_username:  python-discord
 
-remote_theme: pmarsceill/just-the-docs
+remote_theme: just-the-docs/just-the-docs
 theme: just-the-docs
 plugins:
   - jekyll-feed


### PR DESCRIPTION
https://github.com/just-the-docs/just-the-docs is the new path to the theme we use for  docs. The user seems to have moved this repo into an org, causing github to redirect, which jekyll does not follow.