### PR TITLE
Bump bot memory limit to 1400Mi

### DIFF
--- a/namespaces/default/bot/deployment.yaml
+++ b/namespaces/default/bot/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             memory: 600Mi
           limits:
             cpu: 1000m
-            memory: 800Mi
+            memory: 1400Mi
         envFrom:
         - secretRef:
             name: bot-env


### PR DESCRIPTION
When running discord.Guild.chunk() this creates a duplicate member cahce before deleting the old one, temporarily using a large amount of memory.

In testing this used 1.1-1.2Gi