### PR TITLE
Add a custom snekbox service for forms

### DIFF
--- a/namespaces/default/snekbox-forms/README.md
+++ b/namespaces/default/snekbox-forms/README.md
@@ -1,0 +1,5 @@
+# Snekbox-forms
+
+This folder contains manifests for a Snekbox service specific to the forms project. This instance has no 3rd party libs installed, unlike regular snekbox, so submissions via forms can only use the stdlib.
+
+The deployment manifest for this service is based on in manifest found inside the snekbox repository at [python-discord/snekbox](https://github.com/python-discord/snekbox), modified only by removing the volume mount, and 3rd party dep installation script.

--- a/namespaces/default/snekbox-forms/deployment.yaml
+++ b/namespaces/default/snekbox-forms/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: snekbox-forms
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: snekbox-forms
+  template:
+    metadata:
+      labels:
+        app: snekbox-forms
+    spec:
+      containers:
+        - name: snekbox-forms
+          image: ghcr.io/python-discord/snekbox:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8060
+          securityContext:
+            privileged: true

--- a/namespaces/default/snekbox-forms/service.yaml
+++ b/namespaces/default/snekbox-forms/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: snekbox-forms
+spec:
+  selector:
+    app: snekbox-forms
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8060


### PR DESCRIPTION
This custom service has no 3rd party libs installed, so submissions via forms can only use the stdlib.

Once merged and deployed, a new secret `SNEKBOX_URL` should be added to forms-backend with the value `http://snekbox-forms.default.svc.cluster.local/eval`