### PR TITLE
Add GitHub App Secrets

### DIFF
--- a/namespaces/default/site/README.md
+++ b/namespaces/default/site/README.md
@@ -5,9 +5,11 @@ This folder contains the manifests for Python Discord site.
 
 The deployment expects the following secrets to be available in `site-env`:
 
-| Environment           | Description                               |
-|-----------------------|-------------------------------------------|
-| DATABASE_URL          | The URL for the Postgresql database.      |
-| METRICITY_DB_URL      | The URL for the Metricity database.       |
-| SECRET_KEY            | Secret key for Django.                    |
-| SENTRY_DSN            | The Sentry Data Source Name.              |
+| Environment           | Description                                                |
+|-----------------------|------------------------------------------------------------|
+| DATABASE_URL          | The URL for the Postgresql database.                       |
+| METRICITY_DB_URL      | The URL for the Metricity database.                        |
+| SECRET_KEY            | Secret key for Django.                                     |
+| SENTRY_DSN            | The Sentry Data Source Name.                               |
+| GITHUB_APP_KEY        | A PEM key for a GitHub Application.                        |
+| GITHUB_APP_ID         | The ID of a GitHub Application (related to the above key). |


### PR DESCRIPTION
Documents the required secrets for a GitHub Application on site (python-discord/site#742). This is already deployed.