### PR TITLE
Bump modmail resource requirements

### DIFF
--- a/namespaces/default/modmail/bot/deployment.yaml
+++ b/namespaces/default/modmail/bot/deployment.yaml
@@ -17,11 +17,11 @@ spec:
           image: ghcr.io/python-discord/modmail:latest
           resources:
             requests:
-              cpu: 50m
-              memory: 350Mi
-            limits:
-              cpu: 100m
+              cpu: 75m
               memory: 500Mi
+            limits:
+              cpu: 125m
+              memory: 750Mi
           imagePullPolicy: "Always"
           volumeMounts:
           - mountPath: /modmailbot/plugins


### PR DESCRIPTION
Over the past 8 days modmail has restarted 17 times due to hitting resource limits.

As of the time of writing this, it is sitting at a steady 427Mi of memory usage.

I believe this change is needed due to the increased size of our server, as well as larger data set of previous logs to go through when searching (causing increased memory usage)