### PR TITLE
Change the snekbox 3.11 service to a 3.10 service.

### DIFF
--- a/namespaces/default/snekbox-310/README.md
+++ b/namespaces/default/snekbox-310/README.md
@@ -1,0 +1,5 @@
+# Snekbox-forms
+
+This folder contains manifests for a Snekbox service that is running Python 3.10.
+
+The deployment manifest for this service is based on in manifest found inside the snekbox repository at [python-discord/snekbox](https://github.com/python-discord/snekbox), modified only by removing the volume mount, 3rd party dep installation script, and hard coding the image version to the most recent 3.10 image on snekbox ghcr.

--- a/namespaces/default/snekbox-310/deployment.yaml
+++ b/namespaces/default/snekbox-310/deployment.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: snekbox-311
+  name: snekbox-310
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: snekbox-311
+      app: snekbox-310
   template:
     metadata:
       labels:
-        app: snekbox-311
+        app: snekbox-310
     spec:
       containers:
-        - name: snekbox-311
-          image: ghcr.io/python-discord/snekbox:3.11
+        - name: snekbox-310
+          image: ghcr.io/python-discord/snekbox:2022.8.14.2
           imagePullPolicy: Always
           ports:
             - containerPort: 8060

--- a/namespaces/default/snekbox-310/service.yaml
+++ b/namespaces/default/snekbox-310/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: snekbox-311
+  name: snekbox-310
 spec:
   selector:
-    app: snekbox-311
+    app: snekbox-310
   ports:
     - protocol: TCP
       port: 80

--- a/namespaces/default/snekbox-311/README.md
+++ b/namespaces/default/snekbox-311/README.md
@@ -1,5 +1,0 @@
-# Snekbox-forms
-
-This folder contains manifests for a Snekbox service that is running Python 3.11. This instance has the same 3rd party libs installed as the regular snekbox, as of 2022-07-13.
-
-The deployment manifest for this service is based on in manifest found inside the snekbox repository at [python-discord/snekbox](https://github.com/python-discord/snekbox), modified only by removing the volume mount, 3rd party dep installation script, and updating the image path to an image using 3.11 and all deps installed.


### PR DESCRIPTION
3.11 is now the default version for snekbox, so we no longer need a special cased 3.11 service. This 3.10 service has been created so that we can retain the version swapping capabilities for the next time we want to do something similar.

This can be merged and applied without worry, as the 3.11 service is not in use.