### PR TITLE
Move Pixels To Port 8000

### DIFF
--- a/namespaces/default/pixels/deployment.yaml
+++ b/namespaces/default/pixels/deployment.yaml
@@ -17,14 +17,14 @@ spec:
           image: ghcr.io/python-discord/pixels:latest
           imagePullPolicy: Always
           ports:
-            - containerPort: 80
+            - containerPort: 8000
           envFrom:
             - secretRef:
                 name: pixels-env
           startupProbe:
             httpGet:
               path: /canvas/size
-              port: 80
+              port: 8000
               httpHeaders:
                 - name: Host
                   value: pixels.pythondiscord.com

--- a/namespaces/default/pixels/service.yaml
+++ b/namespaces/default/pixels/service.yaml
@@ -8,4 +8,4 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8000


### PR DESCRIPTION
Port 80 is no longer accessible in Kubernetes v1.26 without modifying the security context, causing this service to continually boot-loop as it fails to bind the port. It would be a good idea to do this to the other services as well, namely patsy.