### PR TITLE
Update Pixels Startup Probe Endpoint

### DIFF
--- a/namespaces/default/pixels/deployment.yaml
+++ b/namespaces/default/pixels/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                 name: pixels-env
           startupProbe:
             httpGet:
-              path: /canvas/size
+              path: /health
               port: 8000
               httpHeaders:
                 - name: Host


### PR DESCRIPTION
Update the endpoint used for the startup probe for pixels.

See python-discord/pixels-v2#135 (internal) for reasoning.
This is tested, but must be redeployed.