### PR TITLE
Pinnwand deployment

### DIFF
--- a/namespaces/default/hastebin/README.md
+++ b/namespaces/default/hastebin/README.md
@@ -1,5 +1,5 @@
 # Hastebin
-These manifests provision an instance of the hastebin service used on https://paste.pythondiscord.com
+These manifests provision an instance of the hastebin service used on https://paste-old.pythondiscord.com
 
 ## How to deploy this service
 - Check the defaults in `defaults-configmap.yaml` match what you want.

--- a/namespaces/default/hastebin/ingress.yaml
+++ b/namespaces/default/hastebin/ingress.yaml
@@ -12,7 +12,7 @@ spec:
       - "*.pythondiscord.com"
     secretName: pythondiscord.com-tls
   rules:
-  - host: paste.pythondiscord.com
+  - host: paste-old.pythondiscord.com
     http:
       paths:
       - path: /

--- a/namespaces/default/pinnwand/README.md
+++ b/namespaces/default/pinnwand/README.md
@@ -1,0 +1,8 @@
+# pinnwand
+These manifests provision an instance of the pinnwand service used on https://paste.pythondiscord.com.
+
+A init-service is used to download the Python Discord banner logo and save it to a volume, as pinnwand expects it to be present within the image.
+
+## Secrets & config
+This deployment expects an env var named `PINNWAND_DATABASE_URI` to exist in a secret called `pinnwand-postgres-connection`.
+All other configuration can be found in `defaults-configmap.yaml`.

--- a/namespaces/default/pinnwand/defaults-configmap.yaml
+++ b/namespaces/default/pinnwand/defaults-configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pinnwand-config
+data:
+  config.toml: |
+    # Maximum size in bytes of pastes
+    paste_size = 524288
+
+    default_selected_lexer = "python"
+    # List of lexers to pin to the top of the dropdown list
+    preferred_lexers = ["python", "pytb", "pycon", "text", "markdown", "restructuredtext", "sql"]
+
+    page_list = ["about", "removal"]
+    footer = 'View <a href="//github.com/supakeen/pinnwand" target="_BLANK">source code</a>, <a href="/removal">removal</a> information, or read the <a href="/about">about</a> page.'
+
+    paste_help = '''<p>Welcome to Python Discord's pastebin, powered by <a href="//github.com/supakeen/pinnwand" target="_BLANK">pinnwand</a>. It allows you to share code with others. If you write code in the text area below and press the paste button you will be given a link you can share with others so they can view your code as well.</p><p>People with the link can view your pasted code, only you can remove your paste and it expires automatically. Note that anyone could guess the URI to your paste so don't rely on it being private.</p>'''
+    expiries.30days = 2592000
+    expiries.7days = 604800
+    expiries.1day = 86400
+
+    ratelimit.read.capacity = 100
+    ratelimit.read.consume = 1
+    ratelimit.read.refill = 2
+
+    ratelimit.create.capacity = 10  # Default is 2
+    ratelimit.create.consume = 1  # Default is 2
+    ratelimit.create.refill = 10  # Default is 1
+
+    ratelimit.delete.capacity = 2
+    ratelimit.delete.consume = 2
+    ratelimit.delete.refill = 1
+
+    report_email = "paste-abuse@pythondiscord.com"

--- a/namespaces/default/pinnwand/defaults-configmap.yaml
+++ b/namespaces/default/pinnwand/defaults-configmap.yaml
@@ -9,7 +9,7 @@ data:
 
     default_selected_lexer = "python"
     # List of lexers to pin to the top of the dropdown list
-    preferred_lexers = ["python", "pytb", "pycon", "text", "markdown", "restructuredtext", "sql"]
+    preferred_lexers = ["python", "autodetect", "pytb", "pycon", "text", "markdown", "restructuredtext", "sql"]
 
     page_list = ["about", "removal"]
     footer = 'View <a href="//github.com/supakeen/pinnwand" target="_BLANK">source code</a>, <a href="/removal">removal</a> information, or read the <a href="/about">about</a> page.'

--- a/namespaces/default/pinnwand/deployment.yaml
+++ b/namespaces/default/pinnwand/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pinnwand
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pinnwand
+  template:
+    metadata:
+      labels:
+        app: pinnwand
+    spec:
+      initContainers:
+        - name: init-service
+          image: busybox:latest
+          command: ["wget", "https://raw.githubusercontent.com/python-discord/branding/main/logos/badge/badge_512x172.png", "-O", "/tmp/logo.png"]
+          volumeMounts:
+            - name: pinnwand-logo
+              mountPath: /tmp/
+      containers:
+        - name: pinnwand
+          image: ghcr.io/supakeen/pinnwand:latest-psql
+          command: ["venv/bin/python3", "-m", "pinnwand", "--configuration-path", "/config/config.toml", "http"]
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 5m
+              memory: 70Mi
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 8000
+          envFrom:
+          - secretRef:
+              name: pinnwand-postgres-connection
+          securityContext:
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: pinnwand-config
+              mountPath: /config/
+            - name: pinnwand-logo
+              mountPath: /usr/app/pinnwand/static/logo.png
+              subPath: logo.png
+      volumes:
+        - name: pinnwand-logo
+          emptyDir: {}
+        - name: pinnwand-config
+          configMap:
+            name: pinnwand-config
+      securityContext:
+        fsGroup: 2000
+        runAsUser: 1000
+        runAsNonRoot: true

--- a/namespaces/default/pinnwand/ingress.yaml
+++ b/namespaces/default/pinnwand/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+    nginx.ingress.kubernetes.io/auth-tls-secret: "kube-system/mtls-client-crt-bundle"
+    nginx.ingress.kubernetes.io/auth-tls-error-page: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+  name: pinnwand
+spec:
+  tls:
+  - hosts:
+      - "*.pythondiscord.com"
+    secretName: pythondiscord.com-tls
+  rules:
+  - host: paste.pythondiscord.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: pinnwand
+            port:
+              number: 80

--- a/namespaces/default/pinnwand/service.yaml
+++ b/namespaces/default/pinnwand/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pinnwand
+spec:
+  selector:
+    app: pinnwand
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
This is not live yet. Currently the deployment exists at `paste-new.pythondiscord.com`.

There is an [open PR](https://github.com/supakeen/pinnwand/pull/159) upstream to have images built & pushed to ghcr, which will mean we can remove the need for a fork too.

This shouldn't be deployed until we have ensured configuration is exactly as we want it.