### PR TITLE
Document usage of white noise.

### DIFF
--- a/namespaces/default/site/README.md
+++ b/namespaces/default/site/README.md
@@ -1,6 +1,15 @@
 # Python Discord Site
 This folder contains the manifests for Python Discord site.
 
+## Serving static files
+
+Usually, a web server like `nginx` should be deployed and configured to serve static files needed by Django. Then we'd put an `Ingress`
+rule to route traffic to the `STATIC_URL` to that webserver.
+Check the [official docs](https://docs.djangoproject.com/en/4.2/howto/static-files/deployment/) for more info.
+
+In this setup, we do it differently thanks to [WhiteNoise](https://whitenoise.readthedocs.io/en/stable/base.html#), which sets up
+a middleware that handles the caching, compression and serving of the static files for us.
+
 ## Secrets
 
 The deployment expects the following secrets to be available in `site-env`:


### PR DESCRIPTION
It can be confusing to people who want to understand/replicate our infra when it comes to serving static files.

I have personally lost quite some time into figuring it out since we don't do it the usual way `Ingreess --> Webserver (Nginx) --> WSGI`

This adds a small header section in `site`'s `README.md` file to mention that.